### PR TITLE
[FIX] auth_faceid: [FIX] res_users: handle transparency in images for…

### DIFF
--- a/auth_faceid/models/res_users.py
+++ b/auth_faceid/models/res_users.py
@@ -15,7 +15,14 @@ class ResUsers(models.Model):
     def _compute_face_encoding(self):
         for user in self.filtered('image_512'):
             image_data = base64.b64decode(user.image_512)
-            image_np = np.array(Image.open(BytesIO(image_data)).convert('RGB'))
+            image = Image.open(BytesIO(image_data))
+
+            if image.mode in ('RGBA', 'LA') or (image.mode == 'P' and 'transparency' in image.info):
+                image = image.convert('RGBA')
+            else:
+                image = image.convert('RGB')
+
+            image_np = np.array(image)
             encodings = face_recognition.face_encodings(image_np)
             if encodings:
                 user.face_encoding = base64.b64encode(encodings[0].tobytes())


### PR DESCRIPTION
… face recognition

This commit updates the `_compute_face_encoding` method to properly handle images that contain transparency (e.g., PNG files with an alpha channel).

Previously, all images were forcibly converted to the RGB format, which removed transparency information and caused a warning from the PIL library. This could lead to incorrect image processing and unnecessary warnings in the logs.

With this fix, images are now checked for transparency before conversion:
- Images with transparency (modes RGBA, LA, or P with transparency) are converted to RGBA to preserve the alpha channel.
- Images without transparency are converted to RGB as usual.

This ensures that images are processed correctly without losing important transparency information, and prevents warnings from being raised in the logs.
